### PR TITLE
fixed snyk issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,5 +70,16 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'org.jetbrains:annotations:16.0.1'
-    implementation 'com.apollographql.apollo:apollo-runtime:2.5.14'
+    
+    // Apollo with excluded vulnerable dependencies
+    implementation('com.apollographql.apollo:apollo-runtime:2.5.14') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
+    }
+    
+    // Explicitly add secure versions to replace excluded ones
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.1.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0'
 }


### PR DESCRIPTION
Enhance security in build.gradle by excluding vulnerable Apollo dependencies and adding secure versions of okhttp and Kotlin standard libraries.